### PR TITLE
Add headless dggui UTF-8 branch tests and coverage note

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -16,6 +16,24 @@ branches with explicit per-file branch/line targets.
 
 ---
 
+## Update (2026-04-13) — `dggui/` branch-coverage push (headless path)
+
+To improve `dggui/` branch coverage without requiring a window-system backend,
+`test/utf8test.cc` was expanded with additional cases that exercise previously
+untested UTF-8 decoding branches:
+
+- 3-byte UTF-8 sequence handling (`0xE0..0xEF` path)
+- 4-byte UTF-8 sequence handling (`0xF0..0xF4` path)
+- the explicit `\xc4\x87` fallback mapping branch
+- mixed-input decoding with ASCII + mapped + unmapped multibyte sequences
+
+These tests target a low-risk, fully headless part of `dggui/` and are intended
+as a first step toward the issue goal of `dggui/` 90% branch coverage.
+A full post-change coverage percentage update is pending a network-enabled CI
+run (the local environment could not fetch all CMake CPM dependencies).
+
+---
+
 ## Baseline (2026-04-11) — branch-coverage push
 
 The numbers below were collected after adding new tests for `directorytest`,

--- a/test/utf8test.cc
+++ b/test/utf8test.cc
@@ -120,6 +120,35 @@ TEST_CASE("UTF8Test")
 		CHECK_EQ(latin1, decoded);
 	}
 
+	SUBCASE("toLatin1_unmapped_three_byte_sequence_is_dropped")
+	{
+		// U+20AC (Euro sign) uses three UTF-8 bytes and is not in map_decode.
+		std::string utf8_str{"\xe2\x82\xac"};
+		CHECK_EQ(std::string(""), utf8.toLatin1(utf8_str));
+	}
+
+	SUBCASE("toLatin1_unmapped_four_byte_sequence_is_dropped")
+	{
+		// U+1F600 (😀) uses four UTF-8 bytes and is not in map_decode.
+		std::string utf8_str{"\xf0\x9f\x98\x80"};
+		CHECK_EQ(std::string(""), utf8.toLatin1(utf8_str));
+	}
+
+	SUBCASE("toLatin1_supports_hardcoded_c_acute_fallback")
+	{
+		// UTF-8 sequence \xc4\x87 is explicitly mapped to latin-1 'c'.
+		std::string utf8_str{"\xc4\x87"};
+		CHECK_EQ(std::string("c"), utf8.toLatin1(utf8_str));
+	}
+
+	SUBCASE("toLatin1_mixed_ascii_two_three_and_four_byte_sequences")
+	{
+		std::string utf8_str{"A\xc3\xa9\xe2\x82\xac\xf0\x9f\x98\x80Z"};
+		// 'A' + latin1 'é' + (drop euro) + (drop emoji) + 'Z'
+		std::string expected{"A\xe9Z"};
+		CHECK_EQ(expected, utf8.toLatin1(utf8_str));
+	}
+
 	SUBCASE("roundtrip_ascii_unchanged")
 	{
 		std::string ascii = "DrumGizmo 0.9.20";


### PR DESCRIPTION
### Motivation

- Increase `dggui/` branch coverage by adding headless, deterministic tests that exercise UTF-8 decoding branches which do not require a GUI backend or event loop.

### Description

- Added four new unit test subcases to `test/utf8test.cc` that exercise `dggui::UTF8::toLatin1()` branches: unmapped 3-byte sequences, unmapped 4-byte sequences, the hardcoded `\xc4\x87` fallback mapping, and a mixed ASCII+2/3/4-byte sequence case.
- Updated `docs/coverage.md` with a dated (2026-04-13) progress note describing this headless `dggui/` branch-coverage step and noting that a full percent update requires a CI run.
- Changes committed and prepared as a follow-up PR on top of the original coverage-improvement request.

### Testing

- Attempted to configure the test build with `cmake -S . -B build -DDG_ENABLE_TESTS=ON`, but the configure step failed in the local environment because CPM could not clone `git://git.drumgizmo.org/hugin.git` (network dependency fetch error), so no automated test binaries were built or executed locally.
- The new test cases are standard doctest unit tests and will be exercised by the CI build when dependencies are available; CI coverage will provide the post-change branch-percentage measurement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dccadede908324bd17051e251f26c4)