### PR TITLE
Add dgvalidator CLI coverage tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -585,6 +585,24 @@ if(DG_ENABLE_CLI)
 	)
 endif()
 
+if(DG_ENABLE_CLI AND DG_ENABLE_DGVALIDATOR)
+	dg_add_doctest_test(dgvalidatortest
+		SOURCES
+			"${CMAKE_SOURCE_DIR}/src/random.cc"
+			"${CMAKE_SOURCE_DIR}/test/drumkit_creator.cc"
+			"${CMAKE_SOURCE_DIR}/test/scopedfile.cc"
+			"${CMAKE_SOURCE_DIR}/test/dgvalidatortest.cc"
+		INCLUDE_DIRS
+			"${DG_HUGIN_SOURCE_DIR}"
+		COMPILE_DEFINITIONS
+			DGVALIDATOR_BIN="$<TARGET_FILE:dgvalidator>"
+		LINK_LIBRARIES
+			SndFile::sndfile
+		DEPENDENCIES
+			dgvalidator
+	)
+endif()
+
 if(DG_ENABLE_LV2)
 	dg_add_doctest_test(lv2test
 		SOURCES

--- a/test/dgvalidatortest.cc
+++ b/test/dgvalidatortest.cc
@@ -1,0 +1,171 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/***************************************************************************
+ *            dgvalidatortest.cc
+ *
+ *  Tue Apr 21 2026
+ *  Copyright 2026 DrumGizmo team
+ *
+ ****************************************************************************/
+
+/*
+ *  This file is part of DrumGizmo.
+ *
+ *  DrumGizmo is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  DrumGizmo is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with DrumGizmo; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ */
+
+#include <doctest/doctest.h>
+
+#include <config.h>
+
+#include "drumkit_creator.h"
+#include "scopedfile.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
+
+struct CommandResult
+{
+  int exit_code;
+  std::string output;
+};
+
+static std::string shellEscape(const std::string& arg)
+{
+#ifndef _WIN32
+  std::string escaped = "'";
+  for(const auto ch : arg)
+  {
+    if(ch == '\'')
+    {
+      escaped += "'\\''";
+    }
+    else
+    {
+      escaped += ch;
+    }
+  }
+  escaped += "'";
+  return escaped;
+#else
+  std::string escaped = "\"";
+  for(const auto ch : arg)
+  {
+    if(ch == '"')
+    {
+      escaped += "\\\"";
+    }
+    else
+    {
+      escaped += ch;
+    }
+  }
+  escaped += "\"";
+  return escaped;
+#endif
+}
+
+static CommandResult runDgvalidator(const std::vector<std::string>& args)
+{
+  std::string command = shellEscape(DGVALIDATOR_BIN);
+  for(const auto& arg : args)
+  {
+    command += " ";
+    command += shellEscape(arg);
+  }
+
+  ScopedFile output_file("");
+  command += " >";
+  command += shellEscape(output_file.filename());
+  command += " 2>&1";
+
+  auto status = std::system(command.c_str());
+  int exit_code = status;
+#ifndef _WIN32
+  if(WIFEXITED(status))
+  {
+    exit_code = WEXITSTATUS(status);
+  }
+#endif
+
+  std::ifstream stream(output_file.filename());
+  std::string output((std::istreambuf_iterator<char>(stream)),
+      std::istreambuf_iterator<char>());
+
+  return {exit_code, output};
+}
+
+struct DgvalidatorFixture
+{
+  DgvalidatorFixture()
+  {
+    kitfile = drumkit_creator.createStdKit("validator_kit");
+  }
+
+  DrumkitCreator drumkit_creator;
+  std::string kitfile;
+};
+
+TEST_CASE_FIXTURE(DgvalidatorFixture, "DgvalidatorCli")
+{
+  SUBCASE("helpPrintsUsage")
+  {
+    auto result = runDgvalidator({"--help"});
+    CHECK_EQ(0, result.exit_code);
+    CHECK_NE(std::string::npos, result.output.find("Usage:"));
+    CHECK_NE(std::string::npos, result.output.find("Options:"));
+  }
+
+  SUBCASE("versionPrintsVersion")
+  {
+    auto result = runDgvalidator({"--version"});
+    CHECK_EQ(0, result.exit_code);
+    CHECK_NE(std::string::npos, result.output.find("DGValidator v"));
+  }
+
+  SUBCASE("missingKitfileReturnsError")
+  {
+    auto result = runDgvalidator({});
+    CHECK_EQ(1, result.exit_code);
+    CHECK_NE(std::string::npos, result.output.find("Missing kitfile."));
+  }
+
+  SUBCASE("missingKitfileOnDiskReturnsError")
+  {
+    auto result = runDgvalidator({"/tmp/dgvalidator-does-not-exist.xml"});
+    CHECK_EQ(1, result.exit_code);
+    CHECK_NE(std::string::npos,
+        result.output.find("XML parse error in '/tmp/dgvalidator-does-not-exist.xml'"));
+  }
+
+  SUBCASE("validKitWithNoAudioReturnsSuccess")
+  {
+    auto result = runDgvalidator({"--no-audio", kitfile});
+    CHECK_EQ(0, result.exit_code);
+  }
+
+  SUBCASE("pedanticTreatsMissingMetadataAsError")
+  {
+    auto result = runDgvalidator({"--no-audio", "--pedantic", kitfile});
+    CHECK_EQ(1, result.exit_code);
+    CHECK_NE(std::string::npos, result.output.find("Missing version field."));
+  }
+}

--- a/test/dgvalidatortest.cc
+++ b/test/dgvalidatortest.cc
@@ -33,6 +33,7 @@
 #include "scopedfile.h"
 
 #include <cstdlib>
+#include <ctime>
 #include <fstream>
 #include <iterator>
 #include <string>
@@ -40,6 +41,7 @@
 
 #ifndef _WIN32
 #include <sys/wait.h>
+#include <unistd.h>
 #endif
 
 struct CommandResult
@@ -150,10 +152,17 @@ TEST_CASE_FIXTURE(DgvalidatorFixture, "DgvalidatorCli")
 
   SUBCASE("missingKitfileOnDiskReturnsError")
   {
-    auto result = runDgvalidator({"/tmp/dgvalidator-does-not-exist.xml"});
+    // Generate a unique non-existent path using process ID and timestamp
+    auto time_val = static_cast<long>(time(nullptr));
+    auto pid_val = static_cast<long>(getpid());
+    std::string nonexistent_path = "/tmp/dgvalidator-test-nonexistent-" +
+        std::to_string(pid_val) + "-" + std::to_string(time_val) + ".xml";
+    // Ensure file does not exist (in case of collision, though extremely unlikely)
+    (void)unlink(nonexistent_path.c_str());
+    auto result = runDgvalidator({nonexistent_path});
     CHECK_EQ(1, result.exit_code);
-    CHECK_NE(std::string::npos,
-        result.output.find("XML parse error in '/tmp/dgvalidator-does-not-exist.xml'"));
+    std::string expected_error = "XML parse error in '" + nonexistent_path + "'";
+    CHECK_NE(std::string::npos, result.output.find(expected_error));
   }
 
   SUBCASE("validKitWithNoAudioReturnsSuccess")

--- a/test/dgvalidatortest.cc
+++ b/test/dgvalidatortest.cc
@@ -46,135 +46,139 @@
 
 struct CommandResult
 {
-  int exit_code;
-  std::string output;
+	int exit_code;
+	std::string output;
 };
 
 static std::string shellEscape(const std::string& arg)
 {
 #ifndef _WIN32
-  std::string escaped = "'";
-  for(const auto ch : arg)
-  {
-    if(ch == '\'')
-    {
-      escaped += "'\\''";
-    }
-    else
-    {
-      escaped += ch;
-    }
-  }
-  escaped += "'";
-  return escaped;
+	std::string escaped = "'";
+	for(const auto ch : arg)
+	{
+		if(ch == '\'')
+		{
+			escaped += "'\\''";
+		}
+		else
+		{
+			escaped += ch;
+		}
+	}
+	escaped += "'";
+	return escaped;
 #else
-  std::string escaped = "\"";
-  for(const auto ch : arg)
-  {
-    if(ch == '"')
-    {
-      escaped += "\\\"";
-    }
-    else
-    {
-      escaped += ch;
-    }
-  }
-  escaped += "\"";
-  return escaped;
+	std::string escaped = "\"";
+	for(const auto ch : arg)
+	{
+		if(ch == '"')
+		{
+			escaped += "\\\"";
+		}
+		else
+		{
+			escaped += ch;
+		}
+	}
+	escaped += "\"";
+	return escaped;
 #endif
 }
 
 static CommandResult runDgvalidator(const std::vector<std::string>& args)
 {
-  std::string command = shellEscape(DGVALIDATOR_BIN);
-  for(const auto& arg : args)
-  {
-    command += " ";
-    command += shellEscape(arg);
-  }
+	std::string command = shellEscape(DGVALIDATOR_BIN);
+	for(const auto& arg : args)
+	{
+		command += " ";
+		command += shellEscape(arg);
+	}
 
-  ScopedFile output_file("");
-  command += " >";
-  command += shellEscape(output_file.filename());
-  command += " 2>&1";
+	ScopedFile output_file("");
+	command += " >";
+	command += shellEscape(output_file.filename());
+	command += " 2>&1";
 
-  auto status = std::system(command.c_str());
-  int exit_code = status;
+	auto status = std::system(command.c_str());
+	int exit_code = status;
 #ifndef _WIN32
-  if(WIFEXITED(status))
-  {
-    exit_code = WEXITSTATUS(status);
-  }
+	if(WIFEXITED(status))
+	{
+		exit_code = WEXITSTATUS(status);
+	}
 #endif
 
-  std::ifstream stream(output_file.filename());
-  std::string output((std::istreambuf_iterator<char>(stream)),
-      std::istreambuf_iterator<char>());
+	std::ifstream stream(output_file.filename());
+	std::string output((std::istreambuf_iterator<char>(stream)),
+	    std::istreambuf_iterator<char>());
 
-  return {exit_code, output};
+	return {exit_code, output};
 }
 
 struct DgvalidatorFixture
 {
-  DgvalidatorFixture()
-  {
-    kitfile = drumkit_creator.createStdKit("validator_kit");
-  }
+	DgvalidatorFixture()
+	{
+		kitfile = drumkit_creator.createStdKit("validator_kit");
+	}
 
-  DrumkitCreator drumkit_creator;
-  std::string kitfile;
+	DrumkitCreator drumkit_creator;
+	std::string kitfile;
 };
 
 TEST_CASE_FIXTURE(DgvalidatorFixture, "DgvalidatorCli")
 {
-  SUBCASE("helpPrintsUsage")
-  {
-    auto result = runDgvalidator({"--help"});
-    CHECK_EQ(0, result.exit_code);
-    CHECK_NE(std::string::npos, result.output.find("Usage:"));
-    CHECK_NE(std::string::npos, result.output.find("Options:"));
-  }
+	SUBCASE("helpPrintsUsage")
+	{
+		auto result = runDgvalidator({"--help"});
+		CHECK_EQ(0, result.exit_code);
+		CHECK_NE(std::string::npos, result.output.find("Usage:"));
+		CHECK_NE(std::string::npos, result.output.find("Options:"));
+	}
 
-  SUBCASE("versionPrintsVersion")
-  {
-    auto result = runDgvalidator({"--version"});
-    CHECK_EQ(0, result.exit_code);
-    CHECK_NE(std::string::npos, result.output.find("DGValidator v"));
-  }
+	SUBCASE("versionPrintsVersion")
+	{
+		auto result = runDgvalidator({"--version"});
+		CHECK_EQ(0, result.exit_code);
+		CHECK_NE(std::string::npos, result.output.find("DGValidator v"));
+	}
 
-  SUBCASE("missingKitfileReturnsError")
-  {
-    auto result = runDgvalidator({});
-    CHECK_EQ(1, result.exit_code);
-    CHECK_NE(std::string::npos, result.output.find("Missing kitfile."));
-  }
+	SUBCASE("missingKitfileReturnsError")
+	{
+		auto result = runDgvalidator({});
+		CHECK_EQ(1, result.exit_code);
+		CHECK_NE(std::string::npos, result.output.find("Missing kitfile."));
+	}
 
-  SUBCASE("missingKitfileOnDiskReturnsError")
-  {
-    // Generate a unique non-existent path using process ID and timestamp
-    auto time_val = static_cast<long>(time(nullptr));
-    auto pid_val = static_cast<long>(getpid());
-    std::string nonexistent_path = "/tmp/dgvalidator-test-nonexistent-" +
-        std::to_string(pid_val) + "-" + std::to_string(time_val) + ".xml";
-    // Ensure file does not exist (in case of collision, though extremely unlikely)
-    (void)unlink(nonexistent_path.c_str());
-    auto result = runDgvalidator({nonexistent_path});
-    CHECK_EQ(1, result.exit_code);
-    std::string expected_error = "XML parse error in '" + nonexistent_path + "'";
-    CHECK_NE(std::string::npos, result.output.find(expected_error));
-  }
+	SUBCASE("missingKitfileOnDiskReturnsError")
+	{
+		// Generate a unique non-existent path using process ID and timestamp
+		auto time_val = static_cast<long>(time(nullptr));
+		auto pid_val = static_cast<long>(getpid());
+		std::string nonexistent_path = "/tmp/dgvalidator-test-nonexistent-" +
+		                               std::to_string(pid_val) + "-" +
+		                               std::to_string(time_val) + ".xml";
+		// Ensure file does not exist (in case of collision, though extremely
+		// unlikely)
+		(void)unlink(nonexistent_path.c_str());
+		auto result = runDgvalidator({nonexistent_path});
+		CHECK_EQ(1, result.exit_code);
+		std::string expected_error =
+		    "XML parse error in '" + nonexistent_path + "'";
+		CHECK_NE(std::string::npos, result.output.find(expected_error));
+	}
 
-  SUBCASE("validKitWithNoAudioReturnsSuccess")
-  {
-    auto result = runDgvalidator({"--no-audio", kitfile});
-    CHECK_EQ(0, result.exit_code);
-  }
+	SUBCASE("validKitWithNoAudioReturnsSuccess")
+	{
+		auto result = runDgvalidator({"--no-audio", kitfile});
+		CHECK_EQ(0, result.exit_code);
+	}
 
-  SUBCASE("pedanticTreatsMissingMetadataAsError")
-  {
-    auto result = runDgvalidator({"--no-audio", "--pedantic", kitfile});
-    CHECK_EQ(1, result.exit_code);
-    CHECK_NE(std::string::npos, result.output.find("Missing version field."));
-  }
+	SUBCASE("pedanticTreatsMissingMetadataAsError")
+	{
+		auto result = runDgvalidator({"--no-audio", "--pedantic", kitfile});
+		CHECK_EQ(1, result.exit_code);
+		CHECK_NE(
+		    std::string::npos, result.output.find("Missing version field."));
+	}
 }


### PR DESCRIPTION
### Motivation
- Increase test coverage for `drumgizmo/dgvalidator.cc` by adding end-to-end CLI tests that exercise argument parsing, file handling and validation modes.

### Description
- Add a new doctest-based test `test/dgvalidatortest.cc` that runs the `dgvalidator` binary and checks `--help`, `--version`, missing-argument handling, non-existent file handling, `--no-audio` success and `--pedantic` failure behavior.
- Wire the test into the test suite by updating `test/CMakeLists.txt` to add a `dgvalidatortest` target gated by `DG_ENABLE_CLI AND DG_ENABLE_DGVALIDATOR`, passing the binary path via `DGVALIDATOR_BIN` and adding `dgvalidator` as a dependency.
- Update one assertion to match actual `dgvalidator` stderr output for the missing-file case (look for the XML parse error message).

### Testing
- Configured and built in debug mode with `cmake -S . -B build -DDG_WITH_DEBUG=ON` and `cmake --build build -j$(nproc)`, which succeeded.
- Configured tests with `-DDG_ENABLE_TESTS=ON` and built the test binaries, which succeeded.
- Running full test suite with `ctest --test-dir build --output-on-failure` in this environment reported unrelated GUI/X11 failures (`widgettest` and `pluginguitest` segfaulting due to `XOpenDisplay`), so full-suite is not green here.
- Built and ran the new test target specifically with `cmake --build build --target dgvalidatortest` and `ctest --test-dir build -R dgvalidatortest --output-on-failure`, and `dgvalidatortest` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d4fe7ec08324a9d7a1ab02453d10)